### PR TITLE
Enable overriding inheritance per-pattern

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name":             "bgilhome/plugin-data-inheritance",
+  "name":             "pattern-lab/plugin-data-inheritance",
   "description":      "Data inheritance based on pattern lineage for Pattern Lab.",
   "keywords":         ["data", "inheritance", "lineage", "pattern lab"],
   "homepage":         "http://patternlab.io",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
       "config": {
         "plugins": {
           "dataInheritance": {
-            "enabled": true
+            "enabled": true,
+            "default": true
           }
         }
       }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name":             "pattern-lab/plugin-data-inheritance",
+  "name":             "bgilhome/plugin-data-inheritance",
   "description":      "Data inheritance based on pattern lineage for Pattern Lab.",
   "keywords":         ["data", "inheritance", "lineage", "pattern lab"],
   "homepage":         "http://patternlab.io",

--- a/src/PatternLab/DataInheritance/PatternLabListener.php
+++ b/src/PatternLab/DataInheritance/PatternLabListener.php
@@ -40,7 +40,7 @@ class PatternLabListener extends \PatternLab\Listener {
       $storePatternData = PatternData::get();
       
       foreach ($storePatternData as $patternStoreKey => $patternData) {
-
+  
         if (isset($patternData["lineages"])
           && is_array($patternData["lineages"])
           && (count($patternData["lineages"]) > 0)

--- a/src/PatternLab/DataInheritance/PatternLabListener.php
+++ b/src/PatternLab/DataInheritance/PatternLabListener.php
@@ -40,7 +40,10 @@ class PatternLabListener extends \PatternLab\Listener {
       
       foreach ($storePatternData as $patternStoreKey => $patternData) {
         
-        if (isset($patternData["lineages"]) && (count($patternData["lineages"]) > 0)) {
+        if (isset($patternData["lineages"])
+          && is_array($patternData["lineages"])
+          && (count($patternData["lineages"]) > 0)
+        ) {
           
           $dataLineage = array();
           

--- a/src/PatternLab/DataInheritance/PatternLabListener.php
+++ b/src/PatternLab/DataInheritance/PatternLabListener.php
@@ -32,24 +32,24 @@ class PatternLabListener extends \PatternLab\Listener {
   * Look up data in lineages, update pattern store data, replace store
   */
   public function inherit() {
-
+    
     if ((bool)Config::getOption("plugins.dataInheritance.enabled")) {
 
       $pluginDefault = (bool)Config::getOption("plugins.dataInheritance.default");
       $storeData        = Data::get();
       $storePatternData = PatternData::get();
-
+      
       foreach ($storePatternData as $patternStoreKey => $patternData) {
 
         if (isset($patternData["lineages"])
           && is_array($patternData["lineages"])
           && (count($patternData["lineages"]) > 0)
         ) {
-
+          
           $dataLineage = array();
 
           foreach($patternData["lineages"] as $lineage) {
-
+            
             // merge the lineage data with the lineage store. newer/higher-level data is more important.
             $lineageKey  = $lineage["lineagePattern"];
             $lineageDataInheritance = isset($storeData["patternSpecific"][$lineageKey]["data"]["data-inheritance"])
@@ -63,21 +63,21 @@ class PatternLabListener extends \PatternLab\Listener {
             if (!empty($lineageData)) {
               $dataLineage = array_replace_recursive($dataLineage, $lineageData);
             }
-
+            
           }
 
           // merge the lineage data with the pattern data. pattern data is more important.
           $dataPattern = isset($storeData["patternSpecific"][$patternStoreKey]) && isset($storeData["patternSpecific"][$patternStoreKey]["data"]) ? $storeData["patternSpecific"][$patternStoreKey]["data"] : array();
           $dataPattern = array_replace_recursive($dataLineage, $dataPattern);
-
+          
           if (!empty($dataPattern)) {
             $storeData["patternSpecific"][$patternStoreKey]["data"] = $dataPattern;
           }
-
+          
         }
 
       }
-
+      
       Data::replaceStore($storeData);
       
     }

--- a/src/PatternLab/DataInheritance/PatternLabListener.php
+++ b/src/PatternLab/DataInheritance/PatternLabListener.php
@@ -32,44 +32,52 @@ class PatternLabListener extends \PatternLab\Listener {
   * Look up data in lineages, update pattern store data, replace store
   */
   public function inherit() {
-    
+
     if ((bool)Config::getOption("plugins.dataInheritance.enabled")) {
-      
+
+      $pluginDefault = (bool)Config::getOption("plugins.dataInheritance.default");
       $storeData        = Data::get();
       $storePatternData = PatternData::get();
-      
+
       foreach ($storePatternData as $patternStoreKey => $patternData) {
-        
+
         if (isset($patternData["lineages"])
           && is_array($patternData["lineages"])
           && (count($patternData["lineages"]) > 0)
         ) {
-          
+
           $dataLineage = array();
-          
+
           foreach($patternData["lineages"] as $lineage) {
-            
+
             // merge the lineage data with the lineage store. newer/higher-level data is more important.
             $lineageKey  = $lineage["lineagePattern"];
-            $lineageData = isset($storeData["patternSpecific"][$lineageKey]) && isset($storeData["patternSpecific"][$lineageKey]["data"]) ? $storeData["patternSpecific"][$lineageKey]["data"] : array();
+            $lineageDataInheritance = isset($storeData["patternSpecific"][$lineageKey]["data"]["data-inheritance"])
+              ? (bool)$storeData["patternSpecific"][$lineageKey]["data"]["data-inheritance"]
+              : $pluginDefault;
+            $lineageData = $lineageDataInheritance
+              && isset($storeData["patternSpecific"][$lineageKey])
+              && isset($storeData["patternSpecific"][$lineageKey]["data"])
+              ? $storeData["patternSpecific"][$lineageKey]["data"]
+              : array();
             if (!empty($lineageData)) {
               $dataLineage = array_replace_recursive($dataLineage, $lineageData);
             }
-            
+
           }
-          
+
           // merge the lineage data with the pattern data. pattern data is more important.
           $dataPattern = isset($storeData["patternSpecific"][$patternStoreKey]) && isset($storeData["patternSpecific"][$patternStoreKey]["data"]) ? $storeData["patternSpecific"][$patternStoreKey]["data"] : array();
           $dataPattern = array_replace_recursive($dataLineage, $dataPattern);
-          
+
           if (!empty($dataPattern)) {
             $storeData["patternSpecific"][$patternStoreKey]["data"] = $dataPattern;
           }
-          
+
         }
-        
+
       }
-      
+
       Data::replaceStore($storeData);
       
     }


### PR DESCRIPTION
This PR adds a config option dataInheritance.default (bool) which describes the default inheritance behaviour (if the plugin is enabled) - i.e. by default, either inherit lineage pattern data or not - and a 'data-inheritance' key (bool) that can be set in pattern data to override that default.

e.g. if dataInheritance.default is false, and pattern 'foobar' has data 'data-inheritance: true', then any pattern including foobar will use the inherited data. Likewise if the default is true, all included patterns will use inherited data, unless their data contains 'data-inheritance: false'.