### PR TITLE
Check $patternData["lineages"] for being an array

### DIFF
--- a/src/PatternLab/DataInheritance/PatternLabListener.php
+++ b/src/PatternLab/DataInheritance/PatternLabListener.php
@@ -40,6 +40,10 @@ class PatternLabListener extends \PatternLab\Listener {
       
       foreach ($storePatternData as $patternStoreKey => $patternData) {
         
+        if ($patternData["lineages"] === false) {
+            $patternData["lineages"] = array();
+        }
+        
         if (isset($patternData["lineages"]) && (count($patternData["lineages"]) > 0)) {
           
           $dataLineage = array();


### PR DESCRIPTION
If `$patternData["lineages"]` equals `false`, make it an empty array to prevent php warning:
```
Warning: count(): Parameter must be an array or an object that implements Countable in /.../pattern-lab/vendor/pattern-lab/plugin-data-inheritance/src/PatternLab/DataInheritance/PatternLabListener.php on line 43
```